### PR TITLE
Fix AttributeError: 'BluetoothTab' object has no attribute 'scan_button'

### DIFF
--- a/src/ui/tabs/bluetooth_tab.py
+++ b/src/ui/tabs/bluetooth_tab.py
@@ -298,19 +298,19 @@ class BluetoothTab(Gtk.Box):
         # Update UI based on Bluetooth state
         if is_enabled:
             # Bluetooth enabled - show scan button
-            self.scan_button.set_visible(True)
+            self.refresh_button.set_visible(True)
             # Update device list
             self.update_device_list()
         else:
             # Bluetooth disabled - hide scan button
-            self.scan_button.set_visible(False)
+            self.refresh_button.set_visible(False)
             # Clear all devices from the list
             for child in self.devices_box.get_children():
                 self.devices_box.remove(child)
             self.devices_box.show_all()
             # If we're discovering, stop it
             if self.is_discovering:
-                self.stop_scan(self.scan_button)
+                self.stop_scan(self.refresh_button)
 
     def on_scan_clicked(self, button):
         """Handle scan button clicks


### PR DESCRIPTION
Everytime the OFF/ON Bluetooth switch is clicked, the following errors appear in the terminal:
```shell
# When disabling Bluetooth:
Traceback (most recent call last):
  File "/nix/store/h6h7z2k2x3pv62qb6pr6jyy5wmspjl5f-better-control-6.11.6/share/better-control/ui/tabs/bluetooth_tab.py", line 306, in on_power_switched
    self.scan_button.set_visible(False)
    ^^^^^^^^^^^^^^^^
AttributeError: 'BluetoothTab' object has no attribute 'scan_button'

# When enabling Bluetooth:
Traceback (most recent call last):
  File "/nix/store/h6h7z2k2x3pv62qb6pr6jyy5wmspjl5f-better-control-6.11.6/share/better-control/ui/tabs/bluetooth_tab.py", line 301, in on_power_switched
    self.scan_button.set_visible(True)
    ^^^^^^^^^^^^^^^^
AttributeError: 'BluetoothTab' object has no attribute 'scan_button'
```

This PR solves the problem changing the `scan_button` to `refresh_button`, which was the correct attribute. Now, the Refresh button disappears when the Bluetooth is OFF, which was the expected behavior.